### PR TITLE
Updates and drops some dependencies.

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,10 +1,10 @@
 {
-  "env": {
-    "es6": true,
-    "node": true,
-    "browser": false
+  "parserOptions": {
+    "ecmaVersion": 2017
   },
-  "parser": "babel-eslint",
+  "env": {
+    "node": true
+  },
   "rules": {
     "brace-style": [2, "1tbs", { "allowSingleLine": true }],
     "camelcase": 2,

--- a/package.json
+++ b/package.json
@@ -25,20 +25,14 @@
   },
   "homepage": "https://github.com/inca/koa-router2#readme",
   "dependencies": {
-    "koa": "^2.0.0",
-    "koa-compose": "^3.1.0",
-    "koa-mount": "^2.0.0",
-    "methods": "^1.1.2",
+    "koa": "^2.5.0",
+    "koa-compose": "^4.0.0",
+    "koa-mount": "^3.0.0",
     "path-to-regexp": "^1.6.0"
   },
   "devDependencies": {
-    "babel-cli": "^6.11.4",
-    "babel-core": "^6.11.4",
-    "babel-eslint": "^6.1.2",
-    "babel-preset-nodejs6": "^1.0.0",
-    "babel-register": "^6.11.6",
-    "eslint": "^3.2.2",
-    "mocha": "^3.0.0",
-    "supertest": "^2.0.0"
+    "eslint": "^4.18.1",
+    "mocha": "^5.0.1",
+    "supertest": "^3.0.0"
   }
 }

--- a/src/router.js
+++ b/src/router.js
@@ -2,17 +2,17 @@
 
 const Koa = require('koa');
 const pathToRegexp = require('path-to-regexp');
-const methods = require('methods');
 const mount = require('koa-mount');
 const compose = require('koa-compose');
+const { METHODS } = require('http');
 
 module.exports = class Router {
 
   constructor() {
     this.app = new Koa();
-    methods.forEach(method => {
-      this[method] = this._createRoute(method);
-    });
+    for (const METHOD of METHODS) {
+      this[METHOD.toLowerCase()] = this._createRoute(METHOD);
+    }
     this.del = this.delete;
     this.all = this._createRoute();
   }
@@ -98,7 +98,6 @@ function matchMethod(ctx, method) {
   if (!method) {
     return true;
   }
-  method = method.toUpperCase();
   return ctx.method === method ||
     method === 'GET' && ctx.method === 'HEAD' ||
     false;

--- a/test/.babelrc
+++ b/test/.babelrc
@@ -1,5 +1,0 @@
-{
-  "presets": [
-    "nodejs6"
-  ]
-}

--- a/test/.eslintrc
+++ b/test/.eslintrc
@@ -1,13 +1,6 @@
 {
-  "globals": {
-    "expect": false,
-    "it": false,
-    "describe": false,
-    "context": false,
-    "before": false,
-    "beforeEach": false,
-    "after": false,
-    "afterEach": false
+  "env": {
+    "mocha": true
   },
   "rules": {
     "max-nested-callbacks": 0

--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -1,3 +1,2 @@
 -R spec
---compilers js:babel-register
 test/**/*.test.js

--- a/test/router.test.js
+++ b/test/router.test.js
@@ -4,6 +4,14 @@ const request = require('supertest');
 const Router = require('../src/router');
 
 describe('Router', function() {
+  let server = null;
+
+  afterEach(done => {
+    if (server) {
+      server.close(() => done());
+      server = null;
+    }
+  });
 
   context('methods', function() {
 
@@ -12,20 +20,24 @@ describe('Router', function() {
     router.post('/', async ctx => ctx.body = 'Hi, post');
     router.all('/', async ctx => ctx.body = 'Hi, everyone');
 
+    beforeEach(() => {
+      server = router.app.listen();
+    });
+
     it('answers GET requests', done => {
-      request(router.app.listen())
+      request(server)
         .get('/')
         .expect('Hi, get', done);
     });
 
     it('answers POST requests', done => {
-      request(router.app.listen())
+      request(server)
         .post('/')
         .expect('Hi, post', done);
     });
 
     it('answers other requests', done => {
-      request(router.app.listen())
+      request(server)
         .put('/')
         .expect('Hi, everyone', done);
     });
@@ -38,20 +50,24 @@ describe('Router', function() {
     router.get('/', async ctx => ctx.body = 'Welcome');
     router.get('/hello', async ctx => ctx.body = 'Hello');
 
+    beforeEach(() => {
+      server = router.app.listen();
+    });
+
     it('matches /', done => {
-      request(router.app.listen())
+      request(server)
         .get('/')
         .expect('Welcome', done);
     });
 
     it('matches paths', done => {
-      request(router.app.listen())
+      request(server)
         .get('/hello')
         .expect('Hello', done);
     });
 
     it('returns 404 on unknown routes', done => {
-      request(router.app.listen())
+      request(server)
         .get('/smth')
         .expect(404, done);
     });
@@ -64,14 +80,18 @@ describe('Router', function() {
     router.get('/hi/:name', async ctx => ctx.body = 'Hi, ' + ctx.params.name);
     router.get('/file/*', async ctx => ctx.body = ctx.params[0]);
 
+    beforeEach(() => {
+      server = router.app.listen();
+    });
+
     it('captures named parameters', done => {
-      request(router.app.listen())
+      request(server)
         .get('/hi/jack')
         .expect('Hi, jack', done);
     });
 
     it('matches splats', done => {
-      request(router.app.listen())
+      request(server)
         .get('/file/foo/bar/baz')
         .expect('foo/bar/baz', done);
     });
@@ -89,20 +109,24 @@ describe('Router', function() {
     router.mount('/prefix', prefixed);
     router.mount(unprefixed);
 
+    beforeEach(() => {
+      server = router.app.listen();
+    });
+
     it('mounts with prefix', done => {
-      request(router.app.listen())
+      request(server)
         .get('/prefix/hi')
         .expect('Hi!', done);
     });
 
     it('mounts without prefix', done => {
-      request(router.app.listen())
+      request(server)
         .get('/hello')
         .expect('Hello!', done);
     });
 
     it('does not match without prefix', done => {
-      request(router.app.listen())
+      request(server)
         .get('/hi')
         .expect(404, done);
     });
@@ -112,6 +136,11 @@ describe('Router', function() {
   context('middleware', function() {
 
     const router = new Router();
+
+    beforeEach(() => {
+      server = router.app.listen();
+    });
+
     router.use(async (ctx, next) => {
       ctx.body = '1';
       await next();
@@ -132,7 +161,7 @@ describe('Router', function() {
     });
 
     it('execute .use middleware in order', done => {
-      request(router.app.listen())
+      request(server)
         .get('/')
         .expect('1234321', done);
     });


### PR DESCRIPTION
In particular:
 - Node provides a `METHODS` field on the HTTP module, so the methods module could be dropped (they're identical, except the built-in version is in upper case).
 - Babel modules can be dropped since ESLint supports the ES features this module uses now.
 - The remaining modules were updated, except for path-to-regexp, which breaks existing behaviour.
 - Updating koa meant that I had to explicity tell the underlying server to close with each test.